### PR TITLE
コンポーネントの型をFCからVFCに変更

### DIFF
--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -1,13 +1,14 @@
-import { FC } from 'react'
+import { VFC } from 'react'
 import styles from './layout.module.scss'
 import PageTitle from '../atoms/PageTitle'
 import BackToHomeButton from '../atoms/BackToHomeButton'
 
 type Props = {
   pageName: string
+  children: React.ReactNode
 }
 
-const Layout: FC<Props> = ({ children, pageName }) => {
+const Layout: VFC<Props> = ({ children, pageName }) => {
   return (
     <>
       <header className={styles['title']}>

--- a/components/organisms/Pagination/Pagination.tsx
+++ b/components/organisms/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { VFC, useState } from 'react'
 import ReactPaginate from 'react-paginate'
 import styles from './Pagination.module.scss'
 
@@ -6,7 +6,7 @@ export type Props = {
   pageItems: string[]
 }
 
-const Pagination: FC<Props> = ({ pageItems }) => {
+const Pagination: VFC<Props> = ({ pageItems }) => {
   const [offset, setOffset] = useState(0)
   const perPage = 4
 

--- a/components/organisms/Pagination/index.tsx
+++ b/components/organisms/Pagination/index.tsx
@@ -1,7 +1,7 @@
-import { FC } from 'react'
+import { VFC } from 'react'
 import Pagination, { Props } from './Pagination'
 
-const PaginationContainer: FC<Props> = ({ pageItems }): JSX.Element => (
+const PaginationContainer: VFC<Props> = ({ pageItems }): JSX.Element => (
   <>
     <Pagination pageItems={pageItems} />
   </>

--- a/stories/examples/Button.tsx
+++ b/stories/examples/Button.tsx
@@ -27,7 +27,7 @@ export interface ButtonProps {
 /**
  * Primary UI component for user interaction
  */
-export const Button: React.FC<ButtonProps> = ({
+export const Button: React.VFC<ButtonProps> = ({
   primary = false,
   size = 'medium',
   backgroundColor,

--- a/stories/examples/Header.tsx
+++ b/stories/examples/Header.tsx
@@ -10,7 +10,7 @@ export interface HeaderProps {
   onCreateAccount: () => void
 }
 
-export const Header: React.FC<HeaderProps> = ({
+export const Header: React.VFC<HeaderProps> = ({
   user,
   onLogin,
   onLogout,

--- a/stories/examples/Page.tsx
+++ b/stories/examples/Page.tsx
@@ -10,7 +10,7 @@ export interface PageProps {
   onCreateAccount: () => void
 }
 
-export const Page: React.FC<PageProps> = ({
+export const Page: React.VFC<PageProps> = ({
   user,
   onLogin,
   onLogout,


### PR DESCRIPTION
React v18で`FC`がなくなりそうなので対応します。